### PR TITLE
Improved logging

### DIFF
--- a/bambou/nurest_connection.py
+++ b/bambou/nurest_connection.py
@@ -314,9 +314,9 @@ class NURESTConnection(object):
 
         self._response = NURESTResponse(status_code=response.status_code, headers=response.headers, data=data, reason=response.reason)
 
-        level = logging.WARNING if self._response.status_code >= 300 else logging.INFO
+        level = logging.WARNING if self._response.status_code >= 300 else logging.DEBUG
 
-        bambou_logger.log(level, '< %s %s %s [%s] ' % (self._request.method, self._request.url, self._request.params if self._request.params else "", self._response.status_code))
+        bambou_logger.info('< %s %s %s [%s] ' % (self._request.method, self._request.url, self._request.params if self._request.params else "", self._response.status_code))
         bambou_logger.log(level, '< headers: %s' % self._response.headers)
         bambou_logger.log(level, '< data:\n%s' % json.dumps(self._response.data, indent=4))
 


### PR DESCRIPTION
No need for info logging of successful headers and data. Unnecessary fills up the log output.

Keeping it in track with the request logging in case of a correct response (<300). In case of status >=300, logging the headers and data.

(Personally, i wouldn't log headers and data in warning cases as well, typically, if someone wants to figure out what is happening on a failed call, debug output should be enabled).
