### PR TITLE
Requests fix

### DIFF
--- a/bambou/nurest_fetcher.py
+++ b/bambou/nurest_fetcher.py
@@ -237,10 +237,10 @@ class NURESTFetcher(list):
             request.set_header('X-Nuage-OrderBy', order_by)
 
         if page:
-            request.set_header('X-Nuage-Page', page)
+            request.set_header('X-Nuage-Page', str(page))
 
         if page_size:
-            request.set_header('X-Nuage-PageSize', page_size)
+            request.set_header('X-Nuage-PageSize', str(page_size))
 
         if len(group_by) > 0:
             header = ", ".join(group_by)

--- a/bambou/nurest_request.py
+++ b/bambou/nurest_request.py
@@ -44,7 +44,7 @@ class NURESTRequest(object):
             self.set_header('X-Nuage-Filter', filter)
 
         if page:
-            self.set_header('X-Nuage-Page', page)
+            self.set_header('X-Nuage-Page', str(page))
 
         if order_by:
             self.set_header('X-Nuage-OrderBy', order_by)
@@ -117,5 +117,9 @@ class NURESTRequest(object):
 
     def set_header(self, header, value):
         """ Set header value """
-
+        # requests>=2.11 only accepts `str` or `bytes` header values
+        # raising an exception here, instead of leaving it to `requests` makes
+        # it easy to know where we passed a wrong header type in the code.
+        if not isinstance(value, (str, bytes)):
+            raise TypeError("header values must be str or bytes, but %s value has type %s" % (header, type(value)))
         self._headers[header] = value

--- a/bambou/nurest_request.py
+++ b/bambou/nurest_request.py
@@ -120,6 +120,10 @@ class NURESTRequest(object):
         # requests>=2.11 only accepts `str` or `bytes` header values
         # raising an exception here, instead of leaving it to `requests` makes
         # it easy to know where we passed a wrong header type in the code.
-        if not isinstance(value, (str, bytes)):
+        if isinstance(value, unicode):
+            # FIXME: this is very python 2.x specific, it needs to be changed
+            # when making bambou python 3.x compliant.
+            value = value.encode()
+        elif not isinstance(value, (str, bytes)):
             raise TypeError("header values must be str or bytes, but %s value has type %s" % (header, type(value)))
         self._headers[header] = value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.5.1
+requests
 future

--- a/tests/functionnal/enterprise/test_count_enterprises.py
+++ b/tests/functionnal/enterprise/test_count_enterprises.py
@@ -99,7 +99,7 @@ class Count(TestCase):
             (fetcher, user, count) = self.user.enterprises.count(page=3)
 
         headers = MockUtils.get_mock_parameter(mock, 'headers')
-        self.assertEqual(headers['X-Nuage-Page'], 3)
+        self.assertEqual(headers['X-Nuage-Page'], '3')
 
     def test_count_with_page_size(self):
         """ HEAD /enterprises count enterprises with page size """
@@ -113,7 +113,7 @@ class Count(TestCase):
             (fetcher, user, count) = self.user.enterprises.count(page_size=10)
 
         headers = MockUtils.get_mock_parameter(mock, 'headers')
-        self.assertEqual(headers['X-Nuage-PageSize'], 10)
+        self.assertEqual(headers['X-Nuage-PageSize'], '10')
 
     def test_count_all_should_raise_exception(self):
         """ HEAD /enterprises count all enterprises should raise exception """

--- a/tests/functionnal/enterprise/test_fetch_enterprises.py
+++ b/tests/functionnal/enterprise/test_fetch_enterprises.py
@@ -105,7 +105,7 @@ class Fetch(TestCase):
             (fetcher, user, enterprises) = self.user.enterprises.fetch(page=2)
 
         headers = MockUtils.get_mock_parameter(mock, 'headers')
-        self.assertEqual(headers['X-Nuage-Page'], 2)
+        self.assertEqual(headers['X-Nuage-Page'], '2')
 
     def test_fetch_with_page_size(self):
         """ GET /enterprises retrieve enterprises with page size """
@@ -116,7 +116,7 @@ class Fetch(TestCase):
             (fetcher, user, enterprises) = self.user.enterprises.fetch(page_size=10)
 
         headers = MockUtils.get_mock_parameter(mock, 'headers')
-        self.assertEqual(headers['X-Nuage-PageSize'], 10)
+        self.assertEqual(headers['X-Nuage-PageSize'], '10')
 
     def test_fetch_all_should_not_raise_exception(self):
         """ GET /enterprises retrieve all enterprises should not raise exception """


### PR DESCRIPTION
there are places in the code where the header values are `int`, but requests >= 2.11 only accept `str` and `bytes`. this PR fixes this issue and relax the requirements on requests version.
