### PR TITLE
When paging is used during  rest requests we have to start from page 0, …

### DIFF
--- a/bambou/nurest_fetcher.py
+++ b/bambou/nurest_fetcher.py
@@ -236,7 +236,7 @@ class NURESTFetcher(list):
         if order_by:
             request.set_header('X-Nuage-OrderBy', order_by)
 
-        if page:
+        if page is not None:
             request.set_header('X-Nuage-Page', str(page))
 
         if page_size:


### PR DESCRIPTION
…but if 0 is given , in request headers page attribute is not added