### PR TITLE
python 3.7 compatibility: async keyword

### DIFF
--- a/bambou/nurest_connection.py
+++ b/bambou/nurest_connection.py
@@ -67,7 +67,7 @@ HTTP_METHOD_DELETE = 'DELETE'
 class NURESTConnection(object):
     """ Connection that enable HTTP requests """
 
-    def __init__(self, request, async, callback=None, callbacks=dict(), root_object=None):
+    def __init__(self, request, isasync, callback=None, callbacks=dict(), root_object=None):
         """ Intializes a new connection for a given request
 
             NURESTConnection object is in charge of the HTTP call. It relies on request library
@@ -88,7 +88,7 @@ class NURESTConnection(object):
         self._transaction_id = uuid.uuid4().hex
 
         self._request = request
-        self._async = async
+        self._async = isasync
         self._callback = callback
         self._callbacks = callbacks
         self._user_info = None
@@ -219,7 +219,7 @@ class NURESTConnection(object):
         return self._has_timeouted
 
     @property
-    def async(self):
+    def isasync(self):
         """ Get async
 
             Returns:
@@ -331,7 +331,7 @@ class NURESTConnection(object):
         bambou_logger.debug('Bambou %s on %s has timeout (timeout=%ss)..' % (self._request.method, self._request.url, self.timeout))
         self._has_timeouted = True
 
-        if self.async:
+        if self.isasync:
             self._callback(self)
         else:
             return self
@@ -431,7 +431,7 @@ class NURESTConnection(object):
         from .nurest_session import NURESTSession
         session = NURESTSession.get_current_session()
 
-        if self.async:
+        if self.isasync:
             thread = threading.Thread(target=self._make_request, kwargs={'session': session})
             thread.is_daemon = False
             thread.start()

--- a/bambou/nurest_fetcher.py
+++ b/bambou/nurest_fetcher.py
@@ -253,7 +253,7 @@ class NURESTFetcher(list):
 
         return self.parent_object.get_resource_url_for_child_type(self.__class__.managed_class())
 
-    def fetch(self, filter=None, order_by=None, group_by=[], page=None, page_size=None, query_parameters=None, commit=True, async=False, callback=None):
+    def fetch(self, filter=None, order_by=None, group_by=[], page=None, page_size=None, query_parameters=None, commit=True, isasync=False, callback=None):
         """ Fetch objects according to given filter and page.
 
             Note:
@@ -284,8 +284,8 @@ class NURESTFetcher(list):
 
         self._prepare_headers(request=request, filter=filter, order_by=order_by, group_by=group_by, page=page, page_size=page_size)
 
-        if async:
-            return self.parent_object.send_request(request=request, async=async, local_callback=self._did_fetch, remote_callback=callback, user_info={'commit': commit})
+        if isasync:
+            return self.parent_object.send_request(request=request, isasync=isasync, local_callback=self._did_fetch, remote_callback=callback, user_info={'commit': commit})
 
         connection = self.parent_object.send_request(request=request, user_info={'commit': commit})
         return self._did_fetch(connection=connection)
@@ -350,7 +350,7 @@ class NURESTFetcher(list):
 
         return self._send_content(content=fetched_objects, connection=connection)
 
-    def get(self, filter=None, order_by=None, group_by=[], page=None, page_size=None, query_parameters=None, commit=True, async=False, callback=None):
+    def get(self, filter=None, order_by=None, group_by=[], page=None, page_size=None, query_parameters=None, commit=True, isasync=False, callback=None):
         """ Fetch object and directly return them
 
             Note:
@@ -377,7 +377,7 @@ class NURESTFetcher(list):
         """
         return self.fetch(filter=filter, order_by=order_by, group_by=group_by, page=page, page_size=page_size, query_parameters=query_parameters, commit=commit)[2]
 
-    def get_first(self, filter=None, order_by=None, group_by=[], query_parameters=None, commit=False, async=False, callback=None):
+    def get_first(self, filter=None, order_by=None, group_by=[], query_parameters=None, commit=False, isasync=False, callback=None):
         """ Fetch object and directly return the first one
 
             Note:
@@ -405,7 +405,7 @@ class NURESTFetcher(list):
         objects = self.get(filter=filter, order_by=order_by, group_by=group_by, page=0, page_size=1, query_parameters=query_parameters, commit=commit)
         return objects[0] if len(objects) else None
 
-    def count(self, filter=None, order_by=None, group_by=[], page=None, page_size=None, query_parameters=None, async=False, callback=None):
+    def count(self, filter=None, order_by=None, group_by=[], page=None, page_size=None, query_parameters=None, isasync=False, callback=None):
         """ Get the total count of objects that can be fetched according to filter
 
             This method can be asynchronous and trigger the callback method
@@ -428,8 +428,8 @@ class NURESTFetcher(list):
 
         self._prepare_headers(request=request, filter=filter, order_by=order_by, group_by=group_by, page=page, page_size=page_size)
 
-        if async:
-            return self.parent_object.send_request(request=request, async=async, local_callback=self._did_count, remote_callback=callback)
+        if isasync:
+            return self.parent_object.send_request(request=request, isasync=isasync, local_callback=self._did_count, remote_callback=callback)
 
         else:
             connection = self.parent_object.send_request(request=request)
@@ -449,7 +449,7 @@ class NURESTFetcher(list):
                 Returns the number of objects found
 
         """
-        return self.count(filter=filter, order_by=order_by, group_by=group_by, page=page, page_size=page_size, query_parameters=query_parameters, async=False)[2]
+        return self.count(filter=filter, order_by=order_by, group_by=group_by, page=page, page_size=page_size, query_parameters=query_parameters, isasync=False)[2]
 
     def _did_count(self, connection):
         """ Called when count if finished """
@@ -465,7 +465,7 @@ class NURESTFetcher(list):
         if 'remote' in connection.callbacks:
             callback = connection.callbacks['remote']
 
-        if connection.async:
+        if connection.isasync:
             if callback:
                 callback(self, self.parent_object, count)
 
@@ -483,7 +483,7 @@ class NURESTFetcher(list):
 
         if connection:
 
-            if connection.async:
+            if connection.isasync:
                 callback = connection.callbacks['remote']
 
                 if callback:

--- a/bambou/nurest_login_controller.py
+++ b/bambou/nurest_login_controller.py
@@ -200,7 +200,7 @@ class NURESTLoginController(object):
         self._url = url
 
     @property
-    def async(self):
+    def isasync(self):
         """ Is asynchronous controller
 
             Returns:
@@ -209,14 +209,14 @@ class NURESTLoginController(object):
 
         return self._async
 
-    @async.setter
-    def async(self, async):
+    @isasync.setter
+    def isasync(self, xasync):
         """ Set asynchronous controller
 
             Args:
                 async: Boolean to say whether or not the controller is async.
         """
-        self._async = async
+        self._async = xasync
 
     # Methods
 

--- a/bambou/nurest_push_center.py
+++ b/bambou/nurest_push_center.py
@@ -222,7 +222,7 @@ class NURESTPushCenter(object):
         request = NURESTRequest(method='GET', url=events_url)
 
         # Force async to False so the push center will have only 1 thread running
-        connection = NURESTConnection(request=request, async=True, callback=self._did_receive_event, root_object=self._root_object)
+        connection = NURESTConnection(request=request, isasync=True, callback=self._did_receive_event, root_object=self._root_object)
 
         if self._timeout:
             if int(time()) - self._start_time >= self._timeout:

--- a/bambou/nurest_root_object.py
+++ b/bambou/nurest_root_object.py
@@ -128,7 +128,7 @@ class NURESTRootObject(NURESTObject):
 
         self._new_password = new_password
 
-    def save(self, async=False, callback=None, encrypted=True):
+    def save(self, isasync=False, callback=None, encrypted=True):
         """ Updates the user and perform the callback method """
 
         if self._new_password and encrypted:
@@ -141,8 +141,8 @@ class NURESTRootObject(NURESTObject):
         data = json.dumps(self.to_dict())
         request = NURESTRequest(method=HTTP_METHOD_PUT, url=self.get_resource_url(), data=data)
 
-        if async:
-            return self.send_request(request=request, async=async, local_callback=self._did_save, remote_callback=callback)
+        if isasync:
+            return self.send_request(request=request, isasync=isasync, local_callback=self._did_save, remote_callback=callback)
         else:
             connection = self.send_request(request=request)
             return self._did_save(connection)
@@ -156,7 +156,7 @@ class NURESTRootObject(NURESTObject):
         controller.password = None
         controller.api_key = self.api_key
 
-        if connection.async:
+        if connection.isasync:
             callback = connection.callbacks['remote']
 
             if connection.user_info:
@@ -166,7 +166,7 @@ class NURESTRootObject(NURESTObject):
         else:
             return (self, connection)
 
-    def fetch(self, async=False, callback=None):
+    def fetch(self, isasync=False, callback=None):
         """ Fetch all information about the current object
 
             Args:
@@ -184,8 +184,8 @@ class NURESTRootObject(NURESTObject):
         """
         request = NURESTRequest(method=HTTP_METHOD_GET, url=self.get_resource_url())
 
-        if async:
-            return self.send_request(request=request, async=async, local_callback=self._did_fetch, remote_callback=callback)
+        if isasync:
+            return self.send_request(request=request, isasync=isasync, local_callback=self._did_fetch, remote_callback=callback)
         else:
             connection = self.send_request(request=request)
             return self._did_retrieve(connection)


### PR DESCRIPTION
In python 3.7 the identifier "async" is now a keyword. This change breaks bambou with 3.7. In this commit, all "async" names have been replaced with "isasync". 

There are minor changes to vspk too (one liners for v4 and v5) but those cannot be committed until bambou begins to work. This is part of my work to port nuage-cats to Python 3.