### PR TITLE
Fixing #33 by using standard_b64encode instead of the urlsafe variant.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
+- '3.9'
 install:
     - pip install -r requirements.txt
     - pip install -r tests-requirements.txt

--- a/bambou/nurest_login_controller.py
+++ b/bambou/nurest_login_controller.py
@@ -28,7 +28,7 @@
 
 from __future__ import unicode_literals
 from builtins import object
-from base64 import urlsafe_b64encode
+from base64 import standard_b64encode
 
 
 class NURESTLoginController(object):
@@ -247,13 +247,13 @@ class NURESTLoginController(object):
             certificate = self._certificate
 
         if certificate:
-            return "XREST %s" % urlsafe_b64encode("{}:".format(user).encode('utf-8')).decode('utf-8')
+            return "XREST %s" % standard_b64encode("{}:".format(user).encode('utf-8')).decode('utf-8')
 
         if api_key:
-            return "XREST %s" % urlsafe_b64encode("{}:{}".format(user, api_key).encode('utf-8')).decode('utf-8')
+            return "XREST %s" % standard_b64encode("{}:{}".format(user, api_key).encode('utf-8')).decode('utf-8')
 
 
-        return "XREST %s" % urlsafe_b64encode("{}:{}".format(user, password).encode('utf-8')).decode('utf-8')
+        return "XREST %s" % standard_b64encode("{}:{}".format(user, password).encode('utf-8')).decode('utf-8')
 
     def reset(self):
         """ Reset controller

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from setuptools import setup
 
 setup(
     name='bambou',
-    version='3.1.2',
+    version='3.1.3',
     author='Nuage Networks',
     author_email='opensource@nuagenetworks.net',
     packages=['bambou', 'bambou.utils'],

--- a/tests/unit/nurestlogin_controller/test_get_authentication_header.py
+++ b/tests/unit/nurestlogin_controller/test_get_authentication_header.py
@@ -26,6 +26,16 @@ class GetAuthenticationHeader(TestCase):
 
         self.assertEquals(controller.get_authentication_header() , 'XREST dXNlcm5hbWU6cGFzc3dvcmQ=')
 
+    def test_get_authentication_header_with_tilde(self):
+        """ Get authentication header with tilde """
+
+        controller = NURESTLoginController()
+        controller.user = 'username'
+        controller.password = 'p~ass~wor~d'
+        controller.api_key = None
+
+        self.assertEquals(controller.get_authentication_header() , 'XREST dXNlcm5hbWU6cH5hc3N+d29yfmQ=')
+
     def test_get_authentication_header_with_api_key(self):
         """ Get authentication header with api key """
 


### PR DESCRIPTION
All standard and bulk processing tests pass